### PR TITLE
Add Makefile and CMake script for building without VS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,31 @@
+# Specify the minimum version for CMake
+cmake_minimum_required(VERSION 3.20)
+
+# Project's name
+project(ncmpp)
+
+# Set the C++ standard
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED True)
+
+# Add the directories where the header files are located
+include_directories(ncmpp/include)
+include_directories(ncmlib/include)
+
+# Add the source files
+file(GLOB NCMPP_SRC "ncmpp/src/*.cpp")
+file(GLOB NCMLIB_SRC "ncmlib/src/*.cpp")
+
+# Create the library
+add_library(ncmlib ${NCMLIB_SRC})
+
+# Create the executable
+add_executable(ncmpp ${NCMPP_SRC})
+
+# Link the libraries
+target_link_libraries(ncmpp ncmlib)
+target_link_libraries(ncmpp ssl)
+target_link_libraries(ncmpp crypto)
+if(WIN32)
+    link_directories(${CMAKE_SOURCE_DIR}/ncmlib/ext/lib)
+endif()

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,40 @@
+# Compiler
+CXX = g++
+
+# Compiler flags
+CXXFLAGS = -Wall -Wextra -std=c++17
+LDFLAGS = -L./ncmlib -lncmlib -lssl -lcrypto
+
+# Include directories
+INCLUDES = -I./ncmpp/include -I./ncmlib/include
+
+# Source files
+SOURCES_NCMPP = $(wildcard ncmpp/src/*.cpp)
+SOURCES_NCMLIB = $(wildcard ncmlib/src/*.cpp)
+
+# Object files
+OBJECTS_NCMPP = $(SOURCES_NCMPP:.cpp=.o)
+OBJECTS_NCMLIB = $(SOURCES_NCMLIB:.cpp=.o)
+
+# Output binary for ncmpp and static library for ncmlib
+OUTPUT_NCMPP = ncmpp/ncmpp
+OUTPUT_NCMLIB = ncmlib/libncmlib.a
+
+# Default target
+all: $(OUTPUT_NCMLIB) $(OUTPUT_NCMPP)
+
+$(OUTPUT_NCMPP): $(OBJECTS_NCMPP) $(OUTPUT_NCMLIB)
+	 $(CXX) $(CXXFLAGS) $(INCLUDES) -o $@ $(OBJECTS_NCMPP) $(LDFLAGS)
+
+$(OUTPUT_NCMLIB): $(OBJECTS_NCMLIB)
+	 ar qc $@ $^
+	 ranlib $@
+
+%.o: %.cpp
+	 $(CXX) $(CXXFLAGS) $(INCLUDES) -c $< -o $@
+
+# Clean target
+clean:
+	 rm -f $(OBJECTS_NCMPP) $(OBJECTS_NCMLIB) $(OUTPUT_NCMPP) $(OUTPUT_NCMLIB)
+
+.PHONY: all clean


### PR DESCRIPTION
I use wsl for programming, I have no VS installed, I use CMake.jpg

(Is it essential to add something to find libssl/libcripto? For most *nix distributions there should be them in a global visible dir and no need to find.